### PR TITLE
Resolved #16

### DIFF
--- a/cleanup.sh
+++ b/cleanup.sh
@@ -8,8 +8,13 @@
 apt-get -y --purge autoremove i2c-tools lighttpd php5-cgi bc
 
 # I2C-Treiber deaktivieren
-cp /etc/modprobe.d/raspi-blacklist.conf.bak /etc/modprobe.d/raspi-blacklist.conf
 sed '/i2c-dev/d' /etc/modules >/etc/modules.tmp && mv /etc/modules.tmp /etc/modules
+modprobe -r i2c_dev
+# Nicht mehr benötigte Dateien aus älteren Versionen entfernen
+if [ -e /etc/modprobe.d/raspi-blacklist.conf.bak ]
+  then
+    rm /etc/modprobe.d/raspi-blacklist.conf.bak
+fi
 
 # raspi-sht21.sh aus den runleveln und logrotate entfernen
 update-rc.d -f raspi-sht21.sh remove

--- a/raspi-blacklist.conf
+++ b/raspi-blacklist.conf
@@ -1,4 +1,0 @@
-# blacklist spi and i2c by default (many users don't need them)
-
-blacklist spi-bcm2708
-#blacklist i2c-bcm2708


### PR DESCRIPTION
Installationsskript arbeitet auf einem Raspberry Pi 2 korrekt. Die I2C-Schnittstelle ist nach einem abschließenden Neustart aktiv. Das neue Installationsskript install.sh muss noch auf einem Raspberry Pi Model B getestet werden. Das Skript cleanup.sh wurde an das neue Installationsskript angepasst.

Der Test auf einem Raspberry Pi Model B war ebenfalls erfolgreich. Damit ist Issue #16 resolved.